### PR TITLE
Fix text padding on project view

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -100,7 +100,7 @@ nav.navbar_top::before {
 /* LARGE */
 @media (min-width: 1024px) {
   .work-item > .work-text {
-    width: 180%;
+    width: 100%;
   }
 }
 


### PR DESCRIPTION
I noticed when browsing your website that the project text seems to be overlapping the project preview, as seen in the image attached below.
![image](https://user-images.githubusercontent.com/83174660/115998974-ca963b80-a5e1-11eb-858f-54e023a85e61.png)
After the changes, this is the new appearance, much cleaner as you can see:
![image](https://user-images.githubusercontent.com/83174660/115999011-eef21800-a5e1-11eb-9af8-6ffd94f25751.png)

Kind regards,
Oliver.

